### PR TITLE
Add wincmd border wrap around

### DIFF
--- a/lua/tmux/navigate.lua
+++ b/lua/tmux/navigate.lua
@@ -25,7 +25,7 @@ local function maybe_change_window(direction, count)
 	return is_window_changed
 end
 
-local function change_window_with_wrap(direction)
+local function change_window_with_cycle(direction)
 	if not maybe_change_window(direction, 1) then
 		wincmd(opposite_directions[direction], 999)
 	end
@@ -55,7 +55,7 @@ local function navigate_to(direction)
 	if is_nvim_border(direction) and has_tmux_target(direction) then
 		wrapper.change_pane(direction)
 	elseif is_nvim_border(direction) and cfg.options.navigation.cycle_navigation then
-		change_window_with_wrap(direction)
+		change_window_with_cycle(direction)
 	else
 		wincmd(direction, 1)
 	end

--- a/lua/tmux/navigate.lua
+++ b/lua/tmux/navigate.lua
@@ -14,15 +14,19 @@ local function winnr(direction)
 	return vim.api.nvim_call_function("winnr", { direction })
 end
 
+local function is_nvim_border(border)
+	return winnr() == winnr("1" .. border)
+end
+
 local function wincmd(direction, count)
 	return vim.api.nvim_command((count or 1) .. "wincmd " .. direction)
 end
 
 local function wincmd_with_cycle(direction)
-	local prev_winnr = winnr()
-	wincmd(direction)
-	if winnr() == prev_winnr then
+	if is_nvim_border(direction) then
 		wincmd(opposite_directions[direction], 999)
+	else
+		wincmd(direction)
 	end
 end
 
@@ -39,10 +43,6 @@ local function has_tmux_target(border)
 		return true
 	end
 	return cfg.options.navigation.cycle_navigation and wrapper.has_neighbor(opposite_directions[border])
-end
-
-local function is_nvim_border(border)
-	return winnr() == winnr("1" .. border)
 end
 
 local function navigate_to(direction)

--- a/lua/tmux/navigate.lua
+++ b/lua/tmux/navigate.lua
@@ -40,7 +40,11 @@ local function has_tmux_target(border)
 		return false
 	end
 
-	return wrapper.has_neighbor(border)
+	if wrapper.has_neighbor(border) then
+		return true
+	else
+		return cfg.options.navigation.cycle_navigation and wrapper.has_neighbor(opposite_directions[border])
+	end
 end
 
 local function is_nvim_border(border)

--- a/lua/tmux/navigate.lua
+++ b/lua/tmux/navigate.lua
@@ -21,8 +21,7 @@ end
 local function maybe_change_window(direction, count)
 	local prev_winnr = winnr()
 	wincmd(direction, count)
-	local is_window_changed = winnr() ~= prev_winnr
-	return is_window_changed
+	return winnr() ~= prev_winnr
 end
 
 local function change_window_with_cycle(direction)
@@ -42,9 +41,8 @@ local function has_tmux_target(border)
 
 	if wrapper.has_neighbor(border) then
 		return true
-	else
-		return cfg.options.navigation.cycle_navigation and wrapper.has_neighbor(opposite_directions[border])
 	end
+	return cfg.options.navigation.cycle_navigation and wrapper.has_neighbor(opposite_directions[border])
 end
 
 local function is_nvim_border(border)

--- a/lua/tmux/navigate.lua
+++ b/lua/tmux/navigate.lua
@@ -3,8 +3,6 @@ local cfg = require("tmux.configuration")
 local keymaps = require("tmux.keymaps")
 local wrapper = require("tmux.wrapper")
 
-local WINNR_MAX = 999
-
 local opposite_directions = {
 	h = 'l',
 	j = 'k',
@@ -28,7 +26,7 @@ end
 
 local function wincmd_with_wrap(direction)
 	if not wincmd_next(direction, 1) then
-		wincmd_next(opposite_directions[direction], WINNR_MAX)
+		wincmd_next(opposite_directions[direction], 999)
 	end
 end
 
@@ -41,22 +39,20 @@ local function has_tmux_target(border)
 		return false
 	end
 
-	if cfg.options.navigation.cycle_navigation then
-		return true
-	end
-
 	return wrapper.has_neighbor(border)
 end
 
-local function is_border(border)
-	return winnr() == winnr("1" .. border) and has_tmux_target(border)
+local function is_nvim_border(border)
+	return winnr() == winnr("1" .. border)
 end
 
 local function navigate_to(direction)
-	if is_border(direction) then
+	if is_nvim_border(direction) and has_tmux_target(direction) then
 		wrapper.change_pane(direction)
-	else
+	elseif is_nvim_border(direction) and cfg.options.navigation.cycle_navigation then
 		wincmd_with_wrap(direction)
+	else
+		wincmd(direction, 1)
 	end
 end
 

--- a/lua/tmux/navigate.lua
+++ b/lua/tmux/navigate.lua
@@ -15,17 +15,17 @@ local function winnr(direction)
 end
 
 local function wincmd(direction, count)
-	return vim.api.nvim_command(count .. "wincmd " .. direction)
+	return vim.api.nvim_command((count or 1) .. "wincmd " .. direction)
 end
 
-local function maybe_change_window(direction, count)
+local function maybe_change_window(direction)
 	local prev_winnr = winnr()
-	wincmd(direction, count)
+	wincmd(direction)
 	return winnr() ~= prev_winnr
 end
 
 local function change_window_with_cycle(direction)
-	if not maybe_change_window(direction, 1) then
+	if not maybe_change_window(direction) then
 		wincmd(opposite_directions[direction], 999)
 	end
 end
@@ -55,7 +55,7 @@ local function navigate_to(direction)
 	elseif is_nvim_border(direction) and cfg.options.navigation.cycle_navigation then
 		change_window_with_cycle(direction)
 	else
-		wincmd(direction, 1)
+		wincmd(direction)
 	end
 end
 

--- a/lua/tmux/navigate.lua
+++ b/lua/tmux/navigate.lua
@@ -4,10 +4,10 @@ local keymaps = require("tmux.keymaps")
 local wrapper = require("tmux.wrapper")
 
 local opposite_directions = {
-	h = 'l',
-	j = 'k',
-	k = 'j',
-	l = 'h',
+	h = "l",
+	j = "k",
+	k = "j",
+	l = "h",
 }
 
 local function winnr(direction)

--- a/lua/tmux/navigate.lua
+++ b/lua/tmux/navigate.lua
@@ -18,14 +18,11 @@ local function wincmd(direction, count)
 	return vim.api.nvim_command((count or 1) .. "wincmd " .. direction)
 end
 
-local function maybe_change_window(direction)
+local function wincmd_with_cycle(direction)
 	local prev_winnr = winnr()
 	wincmd(direction)
-	return winnr() ~= prev_winnr
-end
-
-local function change_window_with_cycle(direction)
-	if not maybe_change_window(direction) then
+	local did_window_move = winnr() ~= prev_winnr
+	if not did_window_move then
 		wincmd(opposite_directions[direction], 999)
 	end
 end
@@ -53,7 +50,7 @@ local function navigate_to(direction)
 	if is_nvim_border(direction) and has_tmux_target(direction) then
 		wrapper.change_pane(direction)
 	elseif is_nvim_border(direction) and cfg.options.navigation.cycle_navigation then
-		change_window_with_cycle(direction)
+		wincmd_with_cycle(direction)
 	else
 		wincmd(direction)
 	end

--- a/lua/tmux/navigate.lua
+++ b/lua/tmux/navigate.lua
@@ -21,8 +21,7 @@ end
 local function wincmd_with_cycle(direction)
 	local prev_winnr = winnr()
 	wincmd(direction)
-	local did_window_move = winnr() ~= prev_winnr
-	if not did_window_move then
+	if winnr() == prev_winnr then
 		wincmd(opposite_directions[direction], 999)
 	end
 end

--- a/lua/tmux/navigate.lua
+++ b/lua/tmux/navigate.lua
@@ -18,15 +18,16 @@ local function wincmd(direction, count)
 	return vim.api.nvim_command(count .. "wincmd " .. direction)
 end
 
-local function wincmd_next(direction, count)
+local function maybe_change_window(direction, count)
 	local prev_winnr = winnr()
 	wincmd(direction, count)
-	return winnr() ~= prev_winnr
+	local is_window_changed = winnr() ~= prev_winnr
+	return is_window_changed
 end
 
-local function wincmd_with_wrap(direction)
-	if not wincmd_next(direction, 1) then
-		wincmd_next(opposite_directions[direction], 999)
+local function change_window_with_wrap(direction)
+	if not maybe_change_window(direction, 1) then
+		wincmd(opposite_directions[direction], 999)
 	end
 end
 
@@ -50,7 +51,7 @@ local function navigate_to(direction)
 	if is_nvim_border(direction) and has_tmux_target(direction) then
 		wrapper.change_pane(direction)
 	elseif is_nvim_border(direction) and cfg.options.navigation.cycle_navigation then
-		wincmd_with_wrap(direction)
+		change_window_with_wrap(direction)
 	else
 		wincmd(direction, 1)
 	end


### PR DESCRIPTION
Closes #7 

~I noticed this only works if `cycle_navigation = false`. My assumption was that `cycle_navigation` is supposed to make tmux panes wrap, but I find that my tmux panes wrap even if this is set to false, so I'm not sure if I'm misunderstanding what it's supposed to do. If you do want to accept this PR, these changes probably shouldn't depend on `cycle_navigation = false`, so we should get that figured out.~
