### PR TITLE
call SyncRegisters on VimEnter

### DIFF
--- a/lua/tmux/copy.lua
+++ b/lua/tmux/copy.lua
@@ -75,6 +75,7 @@ function M.setup()
             autocmd TextYankPost * call PostYank(v:event)
             autocmd CmdlineEnter * call SyncRegisters()
             autocmd CmdwinEnter : call SyncRegisters()
+            autocmd VimEnter * call SyncRegisters()
         endif
     ]])
 


### PR DESCRIPTION
Ensure clipboard is synced on starting vim.

This fixes an issue where if you immediately enter vim, and try to paste from register `"` , it would be incorrect because `sync_registers` would not have been called yet.