### PR TITLE
fix(validation): correctly parse next-x.x versions

### DIFF
--- a/lua/tmux/wrapper/tmux.lua
+++ b/lua/tmux/wrapper/tmux.lua
@@ -32,10 +32,9 @@ local function execute(arg, pre)
 end
 
 local function get_version()
-    local result = execute("-V")
-    local version = result:sub(result:find(" ") + 1)
-
-    return version:gsub("[^%.%w]", "")
+    local result = vim.split(execute("-V"), "\n")
+    local version = result[1]:gsub("tmux ", ""):match("%d.%d%w?")
+    return version
 end
 
 local M = {


### PR DESCRIPTION
Fixes #56

Tested on

```console
❯ tmux -V
tmux next-3.4
❯ /usr/bin/tmux -V
tmux 3.2a
```