### PR TITLE
Fix `sync_clipboard` option.

### DIFF
--- a/lua/tmux/copy.lua
+++ b/lua/tmux/copy.lua
@@ -119,8 +119,8 @@ function M.setup()
         vim.g.clipboard = {
             name = "tmuxclipboard",
             copy = {
-                ["+"] = "tmux load-buffer -",
-                ["*"] = "tmux load-buffer -",
+                ["+"] = "tmux load-buffer -w -",
+                ["*"] = "tmux load-buffer -w -",
             },
             paste = {
                 ["+"] = "tmux save-buffer -",


### PR DESCRIPTION
When using the `redirect_to_clipboard` option, we correctly use the `-w`
flag to tell tmux to sync with the system clipboard. However, the flag
is missing when using only the `sync_clipboard` option.