### PR TITLE
fix: inconsistent window resizing

### DIFF
--- a/lua/tmux/resize.lua
+++ b/lua/tmux/resize.lua
@@ -42,7 +42,7 @@ function M.to_left()
     elseif is_border then
         nvim.resize("x", "+", options.resize.resize_step_x)
     else
-        nvim.resize("x", "-", options.resize.resize_step_x)
+        vim.fn.win_move_separator(0, -options.resize.resize_step_x)
     end
 end
 
@@ -50,10 +50,10 @@ function M.to_bottom()
     local is_border = nvim.is_nvim_border("j")
     if is_border and is_tmux_target("j") then
         tmux.resize("j", options.resize.resize_step_y)
-    elseif is_border and nvim.winnr() ~= nvim.winnr("1k") then
+    elseif is_border then
         nvim.resize("y", "-", options.resize.resize_step_y)
     else
-        nvim.resize("y", "+", options.resize.resize_step_y)
+        vim.fn.win_move_statusline(0, options.resize.resize_step_y)
     end
 end
 
@@ -64,7 +64,7 @@ function M.to_top()
     elseif is_border then
         nvim.resize("y", "+", options.resize.resize_step_y)
     else
-        nvim.resize("y", "-", options.resize.resize_step_y)
+        vim.fn.win_move_statusline(0, -options.resize.resize_step_y)
     end
 end
 
@@ -75,7 +75,7 @@ function M.to_right()
     elseif is_border then
         nvim.resize("x", "-", options.resize.resize_step_x)
     else
-        nvim.resize("x", "+", options.resize.resize_step_x)
+        vim.fn.win_move_separator(0, options.resize.resize_step_x)
     end
 end
 


### PR DESCRIPTION
Mapping commands `horizontal/vertical resize ...` to motion keys (`h`/`j`/`k`/`l`) can cause inconsistency when resizing windows, for example, it is possible that calling `tmux.resize_buttom()` moves split bar up instead of moving it down, which is likely to occur when resizing a window in the middle, i.e. not touching any border of the screen/terminal.

Here's a demo of this issue:

- Current behavior:
    Pressing `<C-A-j>` (mapped to `tmux.resize_bottom`) moves split bar up, pressing `<C-A-k>` (mapped to `tmux.resize_top`) moves split bar down, which is not expected:

https://user-images.githubusercontent.com/76579810/209426078-44656bf8-b824-4f5f-830e-b39d29038ac9.mp4

- Behavior after fix:
    Use `vim.fn.win_move_statusline()` and `vim.fn.win_move_separator()` to achieve a consistent window resizing behavior:

https://user-images.githubusercontent.com/76579810/209426311-ffe6c4d7-8ff3-451a-8797-b3d9f8f27398.mp4



