### PR TITLE
fix error message on startup on neovim 0.10

### DIFF
--- a/lua/tmux/copy.lua
+++ b/lua/tmux/copy.lua
@@ -18,7 +18,7 @@ local function sync_unnamed_register(buffer_name)
 end
 
 local function sync_registers(passed_key)
-    log.debug(string.format("sync_registers: %s", passed_key))
+    log.debug(string.format("sync_registers: %s", tostring(passed_key)))
 
     local ignore_buffers = options.copy_sync.ignore_buffers
     local offset = options.copy_sync.register_offset


### PR DESCRIPTION
that's the error message i'm talking about:
```
...m/site/pack/packer/start/tmux.nvim/lua/tmux/copy.lua:21: bad argument #2 to 'format' (string expected, got nil)
stack traceback:
^I[C]: in function 'format'
^I...m/site/pack/packer/start/tmux.nvim/lua/tmux/copy.lua:21: in function <...m/site/pack/packer/start/tmux.nvim/lua/tmux/copy.lua:20>
...m/site/pack/packer/start/tmux.nvim/lua/tmux/copy.lua:21: bad argument #2 to 'format' (string expected, got nil)
stack traceback:
^I[C]: in function 'format'
^I...m/site/pack/packer/start/tmux.nvim/lua/tmux/copy.lua:21: in function <...m/site/pack/packer/start/tmux.nvim/lua/tmux/copy.lua:20> function: 0xaaaaf6fc4f10 ...m/site/pack/packer/start/tmux.nvim/lua/tm
ux/copy.lua:21: bad argument #2 to 'format' (string expected, got nil)
stack traceback:
^I[C]: in function 'format'
^I...m/site/pack/packer/start/tmux.nvim/lua/tmux/copy.lua:21: in function <...m/site/pack/packer/start/tmux.nvim/lua/tmux/copy.lua:20>
```