### PR TITLE
feat: opt-out keymaps of sync_registers before pasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ The following defaults are given:
         -- synchronizes registers *, +, unnamed, and 0 till 9 with tmux buffers.
         sync_registers = true,
 
+        -- synchronizes registers when pressing p and P.
+        sync_registers_keymap_put = true,
+
+        -- synchronizes registers when pressing (C-r) and ".
+        sync_registers_keymap_reg = true,
+
         -- syncs deletes with tmux clipboard as well, it is adviced to
         -- do so. Nvim does not allow syncing registers 0 and 1 without
         -- overwriting the unnamed register. Thus, ddp would not be possible.

--- a/lua/tmux/configuration/options.lua
+++ b/lua/tmux/configuration/options.lua
@@ -43,6 +43,12 @@ local M = {
         -- synchronizes registers *, +, unnamed, and 0 till 9 with tmux buffers.
         sync_registers = true,
 
+        -- synchronizes registers when pressing p and P.
+        sync_registers_keymap_put = true,
+
+        -- synchronizes registers when pressing (C-r) and ".
+        sync_registers_keymap_reg = true,
+
         -- syncs deletes with tmux clipboard as well, it is adviced to
         -- do so. Nvim does not allow syncing registers 0 and 1 without
         -- overwriting the unnamed register. Thus, ddp would not be possible.

--- a/lua/tmux/copy.lua
+++ b/lua/tmux/copy.lua
@@ -91,30 +91,40 @@ function M.setup()
             sync_registers = sync_registers,
         }
 
-        keymaps.register("n", {
-            ['"'] = [[v:lua.tmux.sync_registers('"')]],
-            ["p"] = [[v:lua.tmux.sync_registers('p')]],
-            ["P"] = [[v:lua.tmux.sync_registers('P')]],
-        }, {
-            expr = true,
-            noremap = true,
-        })
+        if options.copy_sync.sync_registers_keymap_put then
+            keymaps.register("n", {
+                ["p"] = [[v:lua.tmux.sync_registers('p')]],
+                ["P"] = [[v:lua.tmux.sync_registers('P')]],
+            }, {
+                expr = true,
+                noremap = true,
+            })
+        end
 
-        -- double C-r to prevent injection:
-        -- https://vim.fandom.com/wiki/Pasting_registers#In_insert_and_command-line_modes
-        keymaps.register("i", {
-            ["<C-r>"] = [[v:lua.tmux.sync_registers("<C-r><C-r>")]],
-        }, {
-            expr = true,
-            noremap = true,
-        })
+        if options.copy_sync.sync_registers_keymap_reg then
+            keymaps.register("n", {
+                ['"'] = [[v:lua.tmux.sync_registers('"')]],
+            }, {
+                expr = true,
+                noremap = true,
+            })
 
-        keymaps.register("c", {
-            ["<C-r>"] = [[v:lua.tmux.sync_registers("<C-r><C-r>")]],
-        }, {
-            expr = true,
-            noremap = true,
-        })
+            -- double C-r to prevent injection:
+            -- https://vim.fandom.com/wiki/Pasting_registers#In_insert_and_command-line_modes
+            keymaps.register("i", {
+                ["<C-r>"] = [[v:lua.tmux.sync_registers("<C-r><C-r>")]],
+            }, {
+                expr = true,
+                noremap = true,
+            })
+
+            keymaps.register("c", {
+                ["<C-r>"] = [[v:lua.tmux.sync_registers("<C-r><C-r>")]],
+            }, {
+                expr = true,
+                noremap = true,
+            })
+        end
     end
 
     if options.copy_sync.sync_clipboard then

--- a/spec/tmux/configuration/options_spec.lua
+++ b/spec/tmux/configuration/options_spec.lua
@@ -13,6 +13,8 @@ describe("configuration options", function()
                 register_offset = 0,
                 sync_clipboard = true,
                 sync_registers = true,
+                sync_registers_keymap_put = true,
+                sync_registers_keymap_reg = true,
                 sync_deletes = true,
                 ignore_buffers = { empty = false },
                 sync_unnamed = true,
@@ -93,6 +95,22 @@ describe("configuration options", function()
         })
         result = require("tmux.configuration.options")
         assert.are.same(false, result.copy_sync.sync_registers)
+
+        config.set({
+            copy_sync = {
+                sync_registers_keymap_put = false,
+            },
+        })
+        result = require("tmux.configuration.options")
+        assert.are.same(false, result.copy_sync.sync_registers_keymap_put)
+
+        config.set({
+            copy_sync = {
+                sync_registers_keymap_reg = false,
+            },
+        })
+        result = require("tmux.configuration.options")
+        assert.are.same(false, result.copy_sync.sync_registers_keymap_reg)
 
         config.set({
             copy_sync = {


### PR DESCRIPTION
After recent refactoring of which-key.nvim 3.x, the which-key.nvim integration provided at https://github.com/aserowy/tmux.nvim/issues/88#issuecomment-1426864257 is no longer applicable due to a [bugfix](https://github.com/folke/which-key.nvim/issues/743#issuecomment-2233637165).

Fortunately, folke provided a much easier approach at https://github.com/folke/which-key.nvim/issues/743#issuecomment-2234460129 that does not require messing with keymaps. This PR opt-out the keymaps to avoid overriding which-key popup.