### PR TITLE
chore: add LUA_PATH info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,13 @@ If you are using nix-shell, you can start a nix-shell and run `fac` (format and 
 stylua lua/ && luacheck lua/ && busted --verbose
 ```
 
+If you're not using nix-shell, don't forget to set the `LUA_PATH` environment variable before running `bursted`.
+
+```sh
+export LUA_PATH="$PWD/?.lua;$PWD/lua/?/init.lua;$PWD/lua/?.lua;$LUA_PATH"
+busted --verbose -c
+```
+
 ## inspiration
 
 ### clipboard harmonization


### PR DESCRIPTION
Added a brief mention of `LUA_PATH` to the README contribution guide.