### PR TITLE
fix: add null safety for tmux pane id handling

### DIFF
--- a/lua/tmux/wrapper/tmux.lua
+++ b/lua/tmux/wrapper/tmux.lua
@@ -75,7 +75,8 @@ function M.get_buffer_names()
 end
 
 function M.get_current_pane_id()
-    return tonumber(get_tmux_pane():sub(2))
+    local pane = get_tmux_pane()
+    return pane and tonumber(pane:sub(2)) or nil
 end
 
 function M.get_window_layout()

--- a/spec/tmux/wrapper/tmux_spec.lua
+++ b/spec/tmux/wrapper/tmux_spec.lua
@@ -1,0 +1,41 @@
+---@diagnostic disable: duplicate-set-field
+describe("tmux wrapper", function()
+    local tmux
+
+    setup(function()
+        require("spec.tmux.mocks.log_mock").setup()
+
+        tmux = require("tmux.wrapper.tmux")
+        _G.vim = { o = { laststatus = 2 } }
+    end)
+
+    it("check get_tmux_pane with nil env", function()
+        local orig_getenv = os.getenv
+        os.getenv = function(var)
+            if var == "TMUX_PANE" then
+                return nil
+            end
+            return orig_getenv(var)
+        end
+
+        local result = tmux.get_current_pane_id()
+        assert.are.same(nil, result)
+
+        os.getenv = orig_getenv
+    end)
+
+    it("check get_tmux_pane with valid env", function()
+        local orig_getenv = os.getenv
+        os.getenv = function(var)
+            if var == "TMUX_PANE" then
+                return "%12"
+            end
+            return orig_getenv(var)
+        end
+
+        local result = tmux.get_current_pane_id()
+        assert.are.same(12, result)
+
+        os.getenv = orig_getenv
+    end)
+end)


### PR DESCRIPTION
Tmux pane ID can be nil when inside of floating pane