### PR TITLE
fix: disable navigation when in command window mode

### DIFF
--- a/lua/tmux/navigation/navigate.lua
+++ b/lua/tmux/navigation/navigate.lua
@@ -14,10 +14,12 @@ function M.to(direction)
         layout.has_tmux_target(direction, options.navigation.persist_zoom, options.navigation.cycle_navigation)
     if (nvim.is_nvim_float() or is_nvim_border) and has_tmux_target then
         tmux.change_pane(direction)
-    elseif is_nvim_border and options.navigation.cycle_navigation then
-        nvim.wincmd(nvim.opposite_direction(direction), 999)
-    elseif not is_nvim_border then
-        nvim.wincmd(direction, vim.v.count)
+    elseif vim.fn.getcmdwintype() == "" then -- if not in command mode
+        if is_nvim_border and options.navigation.cycle_navigation then
+            nvim.wincmd(nvim.opposite_direction(direction), 999)
+        elseif not is_nvim_border then
+            nvim.wincmd(direction, vim.v.count)
+        end
     end
 end
 

--- a/spec/tmux/navigation/navigate_spec.lua
+++ b/spec/tmux/navigation/navigate_spec.lua
@@ -22,7 +22,7 @@ describe("navigate.to", function()
         _G.vim.fn = {
             getcmdwintype = function()
                 return ""
-            end
+            end,
         }
     end)
 
@@ -181,7 +181,7 @@ describe("navigate.to", function()
         _G.vim.fn = {
             getcmdwintype = function()
                 return "="
-            end
+            end,
         }
         options.navigation.cycle_navigation = false
         layout.has_tmux_target = function()

--- a/spec/tmux/navigation/navigate_spec.lua
+++ b/spec/tmux/navigation/navigate_spec.lua
@@ -19,6 +19,11 @@ describe("navigate.to", function()
         tmux = require("tmux.wrapper.tmux")
 
         _G.vim = { v = { count = 1 } }
+        _G.vim.fn = {
+            getcmdwintype = function()
+                return ""
+            end
+        }
     end)
 
     it("check with no nvim borders", function()
@@ -170,5 +175,34 @@ describe("navigate.to", function()
 
         navigate.to("l")
         assert.are.same("l", last_called_direction)
+    end)
+
+    it("check no navigation in command mode", function()
+        _G.vim.fn = {
+            getcmdwintype = function()
+                return "="
+            end
+        }
+        options.navigation.cycle_navigation = false
+        layout.has_tmux_target = function()
+            return false
+        end
+        nvim.is_nvim_border = function()
+            return false
+        end
+        nvim.is_nvim_float = function()
+            return false
+        end
+
+        local last_called_direction = ""
+        nvim.wincmd = function(direction)
+            last_called_direction = direction
+        end
+
+        navigate.to("h")
+        assert.are.same("", last_called_direction)
+
+        navigate.to("l")
+        assert.are.same("", last_called_direction)
     end)
 end)


### PR DESCRIPTION
Prevents navigation from being triggered while in command window mode, which could lead to unexpected behavior. This ensures navigation commands only work in normal buffer windows.

Closes #113